### PR TITLE
Added ability to manually specify table colours

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ function MyComponent() {
             {
               name: "orders",
               primaryKey: "id",
+              color: "yellow",  // Optional. Use this specific color rather than those defined in tableColors
               columns: [
                 {
                   name: "id",

--- a/src/RelationshipDiagram.tsx
+++ b/src/RelationshipDiagram.tsx
@@ -46,6 +46,7 @@ type ForeignKey = {
 type DatabaseTableInfo = {
   name: string;
   primaryKey: string | string[];
+  color?: string;
   columns: {
     name: string;
     type: DataType;
@@ -296,6 +297,7 @@ function RelationshipDiagram({
       let prevTableMaxY = 0;
       for (const [index, table] of tables.entries()) {
         const id = getRef(table.schemaName, table.name);
+        const tableColor = table.color ? table.color : tableColors[nodes.length % tableColors.length];
         if (nodes.some((node) => node.data.id === id)) {
           continue;
         }
@@ -320,7 +322,7 @@ function RelationshipDiagram({
             id,
             table,
             foreignKeysReferencingTable,
-            color: tableColors[nodes.length % tableColors.length],
+            color: tableColor,
           },
           position: {
             x: xPosition,

--- a/src/RelationshipDiagram.tsx
+++ b/src/RelationshipDiagram.tsx
@@ -297,7 +297,9 @@ function RelationshipDiagram({
       let prevTableMaxY = 0;
       for (const [index, table] of tables.entries()) {
         const id = getRef(table.schemaName, table.name);
-        const tableColor = table.color ? table.color : tableColors[nodes.length % tableColors.length];
+        const tableColor = table.color
+          ? table.color
+          : tableColors[nodes.length % tableColors.length];
         if (nodes.some((node) => node.data.id === id)) {
           continue;
         }


### PR DESCRIPTION
# Description
I want the ability to define colours per table.

I've got many databases and I'm looking to document how they relate to each-other. I want to colour each table according to the database it comes from.
This is so that our data engineers can understand how to link data from separate databases in our warehouse.

## Usage

```javascript
[
  {
    // ...
    tables: [
      {
        name: "orders",
        primaryKey: "id",
        color: "yellow",   // <-- New optional argument
        columns: [
          // ...
        ],
      }
    ]
    // ...
  }
]
```

# Changelog
## Added
* Tables can now have their own custom colour rather than relying on the `tableColors` colour pool.