### PR TITLE
Added arrays and json data types

### DIFF
--- a/src/RelationshipDiagram.tsx
+++ b/src/RelationshipDiagram.tsx
@@ -28,10 +28,16 @@ import { mdiKeyLink, mdiKey, mdiLinkVariant } from "@mdi/js";
 export type DataType =
   | "binary"
   | "number"
+  | "number[]"
   | "boolean"
+  | "boolean[]"
   | "text"
+  | "text[]"
   | "datetime"
+  | "datetime[]"
+  | "uuid"
   | "hierarchical"
+  | "json"
   | "geometric"
   | "money"
   | "other";


### PR DESCRIPTION
# Description

We use a few json and array columns in our databases and I want to be more specific with the column data types.

# Changelog
## Added
* The following data types are now also accepted:
  * `number[]`
  * `boolean[]`
  * `text[]`
  * `datetime[]`
  * `json`